### PR TITLE
chore(typescript): update typescript settings

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
-    "target": "ES6",
-    "moduleResolution": "Node",
-    "outDir": "build",
+    "target": "ESNext",
+    "module": "CommonJS",
+    "moduleResolution": "node",
     "strict": true,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "outDir": "build"
   },
   "include": ["src/**/*", "tests/**/*"]
 }


### PR DESCRIPTION
This PR updates the typescript settings in order to:
* Be more time independent;
* Have more clarity regarding the module strategy being used;
* Remove options that are already covered by the default settings of typescript.